### PR TITLE
[fix] 컬러차트 간결화 및 온보딩 mvvmc 패턴 구분

### DIFF
--- a/myGarden.xcodeproj/xcuserdata/zezekim.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/myGarden.xcodeproj/xcuserdata/zezekim.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "9F7D3481-CC51-4CA1-87E9-836F02363974"
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/myGarden/Core/Colors/ColorChart.swift
+++ b/myGarden/Core/Colors/ColorChart.swift
@@ -10,110 +10,82 @@ import SwiftUI
 
 
 enum ColorChart {
-    // primary 색상
+    // Primary 색상
     static var primary: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "3E7B27") : UIColor(hex: "5CB338")
-        }
+        dynamicColor(dark: "3E7B27", light: "5CB338")
     }
-    
+
     static var primaryAsh: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "A5B68D") : UIColor(hex: "85A98F")
-        }
+        dynamicColor(dark: "A5B68D", light: "85A98F")
     }
 
-    // secondary 색상
+    // Secondary 색상
     static var secondary: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "638C6D") : UIColor(hex: "BFD8AF")
-        }
+        dynamicColor(dark: "638C6D", light: "BFD8AF")
     }
 
-    // background 색상
+    // Background 색상
     static var background: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "333333") : UIColor(hex: "FFFFFF")
-        }
+        dynamicColor(dark: "333333", light: "FFFFFF")
     }
 
-    // text 색상
+    // Text 색상
     static var text: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor.white : UIColor.black
-        }
+        dynamicColor(dark: "FFFFFF", light: "000000")
     }
 
-    // textFieldBackground 색상
+    // TextField 색상
     static var textFieldBackground: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "333333") : UIColor(hex: "F5F5F5")
-        }
+        dynamicColor(dark: "333333", light: "F5F5F5")
     }
 
-    // textFieldBorder 색상
     static var textFieldBorder: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "555555") : UIColor(hex: "BFD8AF")
-        }
+        dynamicColor(dark: "555555", light: "BFD8AF")
     }
 
-    // textFieldFocus 색상
     static var textFieldFocus: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "1E88E5") : UIColor(hex: "1976D2")
-        }
+        dynamicColor(dark: "1E88E5", light: "1976D2")
     }
 
-    // border 색상
+    // Border 색상
     static var border: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "9DBC98") : UIColor(hex: "99BC85")
-        }
+        dynamicColor(dark: "9DBC98", light: "99BC85")
     }
 
-    // border background 색상
     static var borderBackground: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "444444") : UIColor(hex: "FFFFFF")
-        }
+        dynamicColor(dark: "444444", light: "FFFFFF")
     }
 
-    // submit 색상
+    // Submit 색상
     static var submit: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "16423C") : UIColor(hex: "0D7C66")
-        }
+        dynamicColor(dark: "16423C", light: "0D7C66")
     }
 
-    // accent 강조 색상
+    // Accent 강조 색상
     static var accent: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "C62E2E") : UIColor(hex: "B8001F")
-        }
+        dynamicColor(dark: "C62E2E", light: "B8001F")
     }
 
-    // placeholder 색상
+    // Placeholder 색상
     static var placeholder: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor.darkGray : UIColor.lightGray
-        }
+        UIColor { $0.userInterfaceStyle == .dark ? .darkGray : .lightGray }
     }
 
-    // success 색상
+    // Success 색상
     static var success: UIColor {
-        UIColor { traitCollection in
-            traitCollection.userInterfaceStyle == .dark ? UIColor(hex: "117554") : UIColor(hex: "86D293")
-        }
+        dynamicColor(dark: "117554", light: "86D293")
     }
 
-    // error 색상
-    static var error: UIColor {
-        UIColor.red
-    }
+    // Error 색상
+    static var error: UIColor { .red }
 
-    // warning 색상
-    static var warning: UIColor {
-        UIColor.orange
+    // Warning 색상
+    static var warning: UIColor { .orange }
+}
+
+extension ColorChart {
+    private static func dynamicColor(dark: String, light: String) -> UIColor {
+        UIColor { $0.userInterfaceStyle == .dark ? UIColor(hex: dark) : UIColor(hex: light) }
     }
 }
+

--- a/myGarden/Feature/Home/HomeCoordinator.swift
+++ b/myGarden/Feature/Home/HomeCoordinator.swift
@@ -14,8 +14,7 @@ class HomeCoordinator : BaseCoordinator {
     init(window: UIWindow?) {
         self.window = window
     }
-    
-    
+
     override func start() {
         let homeViewController = HomeViewController()
         window?.rootViewController = homeViewController
@@ -25,6 +24,5 @@ class HomeCoordinator : BaseCoordinator {
             onboardingCoordinator.start()
         }
     }
-    
-    
+
 }

--- a/myGarden/Feature/Home/HomeViewController.swift
+++ b/myGarden/Feature/Home/HomeViewController.swift
@@ -23,10 +23,9 @@ class HomeViewController : BaseViewController {
         button.frame = CGRect(x: 100, y: 200, width: 200, height: 50)
         button.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
         view.addSubview(button)
-
+        
     }
     @objc func buttonTapped() {
         viewModel.reset()
-        view.layoutIfNeeded()
     }
 }

--- a/myGarden/Feature/Onboarding/OnboardingCoordinator.swift
+++ b/myGarden/Feature/Onboarding/OnboardingCoordinator.swift
@@ -7,9 +7,9 @@
 import UIKit
 import RxSwift
 
-class OnboardingCoordinator: BaseCoordinator {
+final class OnboardingCoordinator: BaseCoordinator {
     var rootViewController : BaseViewController
-   
+    
     
     init(rootViewController: BaseViewController) {
         self.rootViewController = rootViewController
@@ -17,14 +17,13 @@ class OnboardingCoordinator: BaseCoordinator {
     
     override func start() {
         let onboardingViewController = OnboardingViewController()
-        UserDefaults.standard.set(true, forKey: "isFirstTime")
+        onboardingViewController.viewModel = OnboardingViewModel(coordinator: self)
         onboardingViewController.modalPresentationStyle = .fullScreen
-        onboardingViewController.coordinator = self
         rootViewController.present(onboardingViewController, animated: true)
-        
     }
+    
     override func finish() {
-        print("onboarding finish")
+        UserDefaults.standard.set(false, forKey: "isFirstTime")
         rootViewController.presentedViewController?.dismiss(animated: true)
     }
 }

--- a/myGarden/Feature/Onboarding/OnboardingViewModel.swift
+++ b/myGarden/Feature/Onboarding/OnboardingViewModel.swift
@@ -13,43 +13,46 @@ import RxCocoa
 
 class OnboardingViewModel {
     let disposeBag = DisposeBag()
-
+    var coordinator: OnboardingCoordinator
+    init(coordinator: OnboardingCoordinator) {
+        self.coordinator = coordinator
+    }
+    
     var _currentPage = BehaviorRelay<Int>(value: 0)
     var currentPage: Observable<Int> {
         return _currentPage.asObservable()
     }
-    func updateCurrentPage(_ newValue: Int) {
-        _currentPage.accept(newValue)
-    }
     
-    private let _onboardingList = BehaviorRelay<[String]>(value: ["img-flowerpot", "img-hand","img-leafs","img-flowerpot", "img-hand","img-leafs"])
+    private let _onboardingList = BehaviorRelay<[String]>(value: ["img-flowerpot", "img-hand", "img-leafs", "img-flowerpot", "img-hand", "img-leafs"])
     var onboardingList: Observable<[String]> {
         return _onboardingList.asObservable()
     }
+    
     var onboardingListCount: Int {
-            return _onboardingList.value.count
+        return _onboardingList.value.count
+    }
+    
+    func updateCurrentPage(_ newValue: Int) {
+        _currentPage.accept(newValue)
+ 
+    }
+    
+    func scrollToNextPage() {
+        if _currentPage.value < onboardingListCount - 1 {
+            updateCurrentPage(_currentPage.value + 1)
+        } else {
+            completeOnboarding()
         }
-    func updatePageIndex(for scrollView: UIScrollView) {
-        let page = Int(scrollView.contentOffset.x / scrollView.frame.width)
-        updateCurrentPage(page)
     }
     
-    func scrollToNextPage(scrollView: UIScrollView) {
-        guard _currentPage.value != onboardingListCount - 1 else { return }
-        updateCurrentPage(_currentPage.value + 1)
-        let nextOffsetX = CGFloat(_currentPage.value) * scrollView.frame.width
-        scrollView.setContentOffset(CGPoint(x: nextOffsetX, y: 0), animated: true)
-    }
-    
-    func scrollToPreviousPage(scrollView: UIScrollView) {
+    func scrollToPreviousPage() {
         guard _currentPage.value > 0 else { return }
         updateCurrentPage(_currentPage.value - 1)
-        let prevOffsetX = CGFloat(_currentPage.value) * scrollView.frame.width
-        scrollView.setContentOffset(CGPoint(x: prevOffsetX, y: 0), animated: true)
-    }
- 
-    func completeOnboarding() {
-        UserDefaults.standard.set(false, forKey: "isFirstTime")
     }
     
+    func completeOnboarding() {
+        coordinator.finish()
+    }
+    
+  
 }


### PR DESCRIPTION
- extension을 통해 컬러차트를 좀더 간결하게 해보도록 했습니다
- mvvmc 패턴에 맞춰서 ui를 아예 뷰모델에 전달하지 않도록 했습니다
- finish를 뷰컨트롤러에서 뷰모델로 이동하였는데 코디네이터가 루트 뷰 컨트롤러를 찾지 못하였습니다 그래서 start시 뷰모델에 코디네이터 자체를 전달하도록 했습니다
- 뷰컨트롤러에서 계속 뷰모델을 옵셔널 바인딩을 해야해서 코디네이터를 싱글톤으로 바꿔보려고 했으나 잘 진행되지 않았습니다..